### PR TITLE
DH-21 Allow API to use agent as a user

### DIFF
--- a/web/config/packages/security.yaml
+++ b/web/config/packages/security.yaml
@@ -5,10 +5,18 @@ security:
     providers:
         parthenon:
             id: Parthenon\User\Security\UserProvider
+        agent:
+            id: App\Security\AgentUserProvider
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
+        api:
+            pattern: ^/api/
+            stateless: true
+            lazy: false
+            provider: agent
+            custom_authenticator: App\Security\ApiKeyAuthenticator
         main:
             pattern: ^/app/
             stateless: false
@@ -33,6 +41,7 @@ security:
         - { path: ^/app/(authenticate|login|logout), roles: PUBLIC_ACCESS }
         - { path: ^/app/user/(signup|password|reset|confirm), roles: PUBLIC_ACCESS }
         - { path: ^/app/, roles: ROLE_USER }
+        - { path: ^/api/, roles: ROLE_API_USER }
 
 
 when@test:

--- a/web/src/Controller/Api/HelloWorldController.php
+++ b/web/src/Controller/Api/HelloWorldController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Security\AgentUser;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Security;
+
+/**
+ * Simple API controller for testing Agent authentication.
+ */
+#[Route('/api/v1')]
+class HelloWorldController extends AbstractController
+{
+    private Security $security;
+
+    public function __construct(Security $security)
+    {
+        $this->security = $security;
+    }
+
+    /**
+     * Simple hello world endpoint to verify API authentication.
+     */
+    #[Route('/hello-world', name: 'api_hello_world', methods: ['GET'])]
+    public function helloWorld(): JsonResponse
+    {
+        $response = [
+            'hello' => 'world'
+        ];
+        
+        // Add agent info if available
+        if ($this->security->getUser() instanceof AgentUser) {
+            /** @var AgentUser $user */
+            $user = $this->security->getUser();
+            $agent = $user->getAgent();
+            
+            $response['agent'] = [
+                'id' => $agent->getId(),
+                'name' => $agent->getName(),
+                'authenticated' => true
+            ];
+        }
+        
+        return new JsonResponse($response);
+    }
+}

--- a/web/src/Repository/ApiKeyRepository.php
+++ b/web/src/Repository/ApiKeyRepository.php
@@ -6,4 +6,24 @@ use Parthenon\Athena\Repository\DoctrineCrudRepository;
 
 class ApiKeyRepository extends DoctrineCrudRepository implements ApiKeyRepositoryInterface
 {
+    /**
+     * Find an enabled API key by its key value.
+     *
+     * @param string $key The API key to look for
+     * @return \App\Entity\ApiKey|null The API key entity if found and enabled, null otherwise
+     */
+    public function findEnabledByKey(string $key): ?\App\Entity\ApiKey
+    {
+        $qb = $this->createQueryBuilder('ak');
+        
+        $qb->where('ak.key = :key')
+           ->andWhere('ak.status = :status')
+           ->andWhere('ak.deletedAt IS NULL')
+           ->andWhere('(ak.expiresAt IS NULL OR ak.expiresAt > :now)')
+           ->setParameter('key', $key)
+           ->setParameter('status', 'active')
+           ->setParameter('now', new \DateTimeImmutable('now'));
+           
+        return $qb->getQuery()->getOneOrNullResult();
+    }
 }

--- a/web/src/Repository/ApiKeyRepositoryInterface.php
+++ b/web/src/Repository/ApiKeyRepositoryInterface.php
@@ -6,4 +6,11 @@ use Parthenon\Athena\Repository\CrudRepositoryInterface;
 
 interface ApiKeyRepositoryInterface extends CrudRepositoryInterface
 {
+    /**
+     * Find an enabled API key by its key value.
+     *
+     * @param string $key The API key to look for
+     * @return \App\Entity\ApiKey|null The API key entity if found and enabled, null otherwise
+     */
+    public function findEnabledByKey(string $key): ?\App\Entity\ApiKey;
 }

--- a/web/src/Security/AgentUser.php
+++ b/web/src/Security/AgentUser.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\Agent;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Represents an Agent as a Symfony User for authentication.
+ */
+class AgentUser implements UserInterface
+{
+    private Agent $agent;
+
+    public function __construct(Agent $agent)
+    {
+        $this->agent = $agent;
+    }
+
+    /**
+     * Get the Agent entity this user represents.
+     */
+    public function getAgent(): Agent
+    {
+        return $this->agent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoles(): array
+    {
+        // Agents get a basic role for API access
+        return ['ROLE_API_USER'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eraseCredentials(): void
+    {
+        // API key authentication doesn't store credentials in the user
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserIdentifier(): string
+    {
+        // Use the agent ID as the identifier
+        return $this->agent->getId();
+    }
+}

--- a/web/src/Security/AgentUserProvider.php
+++ b/web/src/Security/AgentUserProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\Agent;
+use App\Repository\AgentRepositoryInterface;
+use App\Repository\ApiKeyRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * Provides Agent entities as Symfony users for API authentication.
+ */
+class AgentUserProvider implements UserProviderInterface
+{
+    private AgentRepositoryInterface $agentRepository;
+    private ApiKeyRepositoryInterface $apiKeyRepository;
+
+    public function __construct(
+        AgentRepositoryInterface $agentRepository,
+        ApiKeyRepositoryInterface $apiKeyRepository
+    ) {
+        $this->agentRepository = $agentRepository;
+        $this->apiKeyRepository = $apiKeyRepository;
+    }
+
+    /**
+     * Find a user by their API key.
+     *
+     * @param string $apiKey The API key to look up
+     * @return AgentUser The user object
+     * @throws UserNotFoundException If the API key is invalid or the agent is not found
+     */
+    public function loadUserByApiKey(string $apiKey): AgentUser
+    {
+        $apiKeyEntity = $this->apiKeyRepository->findEnabledByKey($apiKey);
+        
+        if (null === $apiKeyEntity) {
+            throw new UserNotFoundException('API Key not found or expired');
+        }
+        
+        $agent = $apiKeyEntity->getAgent();
+        
+        if ($agent->getStatus()->value !== 'enabled') {
+            throw new UserNotFoundException('Agent is not enabled');
+        }
+        
+        return new AgentUser($agent);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        // This method is required by the interface but will be delegated
+        // to the authenticator which will call loadUserByApiKey instead
+        throw new \RuntimeException('Use loadUserByApiKey instead');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshUser(UserInterface $user): UserInterface
+    {
+        if (!$user instanceof AgentUser) {
+            throw new UnsupportedUserException(sprintf('Invalid user class "%s".', get_class($user)));
+        }
+
+        $agent = $this->agentRepository->findById($user->getAgent()->getId());
+        
+        if (!$agent) {
+            throw new UserNotFoundException('Agent no longer exists');
+        }
+        
+        return new AgentUser($agent);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass(string $class): bool
+    {
+        return AgentUser::class === $class;
+    }
+}

--- a/web/src/Security/ApiKeyAuthenticator.php
+++ b/web/src/Security/ApiKeyAuthenticator.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+/**
+ * Authenticator for API key-based authentication.
+ */
+class ApiKeyAuthenticator extends AbstractAuthenticator
+{
+    private AgentUserProvider $agentUserProvider;
+    
+    // API key can be provided in header or as a query parameter
+    private const API_KEY_HEADER = 'X-API-KEY';
+    private const API_KEY_QUERY_PARAM = 'api_key';
+
+    public function __construct(AgentUserProvider $agentUserProvider)
+    {
+        $this->agentUserProvider = $agentUserProvider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request): bool
+    {
+        // Only support API routes
+        return str_starts_with($request->getPathInfo(), '/api/');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function authenticate(Request $request): Passport
+    {
+        // Extract API key from request (header or query param)
+        $apiKey = $request->headers->get(self::API_KEY_HEADER);
+        
+        if (!$apiKey) {
+            $apiKey = $request->query->get(self::API_KEY_QUERY_PARAM);
+        }
+
+        if (!$apiKey) {
+            throw new CustomUserMessageAuthenticationException('API key is missing');
+        }
+
+        // Create a user badge that will load the user via the API key
+        return new SelfValidatingPassport(
+            new UserBadge($apiKey, function (string $apiKey) {
+                return $this->agentUserProvider->loadUserByApiKey($apiKey);
+            })
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        // On success, continue with the request
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        $data = [
+            'error' => 'Authentication failed',
+            'message' => $exception->getMessage()
+        ];
+
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
+    }
+}


### PR DESCRIPTION
This PR implements the changes required for DH-21, allowing API to use Agent as a user.

## Changes:
- Added `findEnabledByKey` method to `ApiKeyRepositoryInterface` and implemented it in `ApiKeyRepository`
- Created `AgentUserProvider` to load agents by their API key
- Created `AgentUser` class to represent an Agent as a Symfony user
- Created `ApiKeyAuthenticator` for API key-based authentication
- Updated `security.yaml` to add an API firewall with the new authenticator and user provider
- Added access control for API routes to require `ROLE_API_USER`
- Created a dummy controller with `/api/v1/hello-world` endpoint for testing

## Test:
- Make a GET request to `/api/v1/hello-world` with a valid API key in the X-API-KEY header

## Jira Ticket:
DH-21